### PR TITLE
Bug 548703 - Error dialog on start-up doesn't handle lots of input

### DIFF
--- a/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtk.h
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtk.h
@@ -35,6 +35,17 @@ struct GTK_PTRS {
 	void		(*gtk_window_set_type_hint)	(GtkWindow*, int);
 	void		(*gtk_window_set_position)	(GtkWindow*, GtkWindowPosition);
 
+	GtkWidget*	(*gtk_dialog_new_with_buttons)	( const gchar*, GtkWindow*, GtkDialogFlags, const gchar* , ...);
+	void		(*gtk_window_set_resizable)	(GtkWindow*, gboolean);
+	void		(*gtk_window_set_default_size)	(GtkWindow*, gint, gint);
+	GtkWidget*	(*gtk_scrolled_window_new)	(GtkAdjustment*, GtkAdjustment*);
+	GtkWidget*	(*gtk_text_view_new)		();
+	GtkTextBuffer*	(*gtk_text_view_get_buffer)	(GtkTextView*);
+	void		(*gtk_text_buffer_set_text)	(GtkTextBuffer*, const gchar*, gint);
+	void		(*gtk_text_view_set_editable)	(GtkTextView*, gboolean);
+	GtkWidget*	(*gtk_dialog_get_content_area)	(GtkDialog *);
+	void		(*gtk_box_pack_start)		(GtkBox*, GtkWidget*, gboolean, gboolean, guint);
+
 	gulong 		(*g_signal_connect_data)	(gpointer, const gchar*, GCallback, gpointer, GClosureNotify, GConnectFlags);
 	gboolean	(*g_main_context_iteration)	(GMainContext*, gboolean);
 	void		(*g_object_unref)			(gpointer);

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtkCommon.c
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtkCommon.c
@@ -55,10 +55,37 @@ void displayMessage(char* title, char* message)
     	return;
     }
 
-  	dialog = gtk.gtk_message_dialog_new(NULL, GTK_DIALOG_DESTROY_WITH_PARENT,
-				   					GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
-				   					"%s", message);
-  	gtk.gtk_window_set_title((GtkWindow*)dialog, title);
+    if (strlen(message) < 500) {
+        dialog = gtk.gtk_message_dialog_new(
+            NULL,// parent window
+            GTK_DIALOG_DESTROY_WITH_PARENT,
+            GTK_MESSAGE_ERROR, GTK_BUTTONS_CLOSE,
+            "%s", message);
+            gtk.gtk_window_set_title((GtkWindow*)dialog, title);
+    } else {
+        dialog = gtk.gtk_dialog_new_with_buttons(
+            title,
+            NULL, // parent window
+            (GtkDialogFlags)(GTK_DIALOG_DESTROY_WITH_PARENT),
+            "Close", GTK_RESPONSE_CLOSE,
+            NULL);
+
+        gtk.gtk_window_set_resizable ((GtkWindow*) dialog, TRUE);
+        gtk.gtk_window_set_default_size((GtkWindow*) dialog, 400, 300);
+
+        GtkWidget* scrolled_window = gtk.gtk_scrolled_window_new (NULL, NULL);
+
+        GtkWidget* view = gtk.gtk_text_view_new ();
+        GtkTextBuffer* buffer = gtk.gtk_text_view_get_buffer ((GtkTextView*) view);
+
+        gtk.gtk_text_buffer_set_text (buffer, message, -1);
+        gtk.gtk_text_view_set_editable((GtkTextView*) view, FALSE);
+
+        GtkWidget* content_area = gtk.gtk_dialog_get_content_area ((GtkDialog*) dialog);
+        gtk.gtk_box_pack_start ((GtkBox*) content_area, scrolled_window, TRUE, TRUE, 0);
+        gtk.gtk_container_add ((GtkContainer*) scrolled_window, view);
+        gtk.gtk_widget_show_all (content_area);
+    }
   	gtk.gtk_dialog_run((GtkDialog*)dialog);
   	gtk.gtk_widget_destroy(dialog);
 }

--- a/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtkInit.c
+++ b/features/org.eclipse.equinox.executable.feature/library/gtk/eclipseGtkInit.c
@@ -47,6 +47,16 @@ static FN_TABLE gtkFunctions[] = {
 	FN_TABLE_ENTRY(gtk_window_set_decorated, 1),
 	FN_TABLE_ENTRY(gtk_window_set_type_hint, 1),
 	FN_TABLE_ENTRY(gtk_window_set_position, 1),
+	FN_TABLE_ENTRY(gtk_dialog_new_with_buttons, 1),
+	FN_TABLE_ENTRY(gtk_window_set_resizable, 1),
+	FN_TABLE_ENTRY(gtk_window_set_default_size, 1),
+	FN_TABLE_ENTRY(gtk_scrolled_window_new, 1),
+	FN_TABLE_ENTRY(gtk_text_view_new, 1),
+	FN_TABLE_ENTRY(gtk_text_view_get_buffer, 1),
+	FN_TABLE_ENTRY(gtk_text_buffer_set_text, 1),
+	FN_TABLE_ENTRY(gtk_text_view_set_editable, 1),
+	FN_TABLE_ENTRY(gtk_dialog_get_content_area, 1),
+	FN_TABLE_ENTRY(gtk_box_pack_start, 1),
 	{ NULL, NULL }
 };
 /* functions from libgdk-3.so.0*/


### PR DESCRIPTION
This change adjusts the error dialog shown at Eclipse start-up, to be
able to display large amount of text. This ensures the dialog shows all
information on JVM start-up errors, since then the JVM arguments are
listed as a very long info.

Change-Id: I577b701d2c4bc54a54a39f3cb5b721a4279beb99
Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>