### PR TITLE
Add Service-Capability for org.osgi.service.condition.Condition

### DIFF
--- a/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi/META-INF/MANIFEST.MF
@@ -97,7 +97,8 @@ Provide-Capability: osgi.service; objectClass:List<String>="org.osgi.service.log
  osgi.service; objectClass:List<String>="org.eclipse.osgi.service.urlconversion.URLConverter"; uses:="org.eclipse.osgi.service.urlconversion",
  osgi.service; objectClass:List<String>="org.eclipse.osgi.service.localization.BundleLocalization"; uses:="org.eclipse.osgi.service.localization",
  osgi.service; objectClass:List<String>="org.eclipse.osgi.service.security.TrustEngine"; uses:="org.eclipse.osgi.service.security",
- osgi.service; objectClass:List<String>="org.eclipse.osgi.signedcontent.SignedContentFactory"; uses:="org.eclipse.osgi.signedcontent"
+ osgi.service; objectClass:List<String>="org.eclipse.osgi.signedcontent.SignedContentFactory"; uses:="org.eclipse.osgi.signedcontent",
+ osgi.service; objectClass:List<String>="org.osgi.service.condition.Condition"; osgi.condition.id="true"; uses:="org.osgi.service.condition"
 Bundle-Name: %systemBundle
 Bundle-SymbolicName: org.eclipse.osgi; singleton:=true
 Bundle-Activator: org.eclipse.osgi.internal.framework.SystemBundleActivator


### PR DESCRIPTION
The default Service-Instance is registered here. So we can provide a Capability.
https://github.com/eclipse-equinox/equinox.framework/blob/3d60fea55492b2e2239c21f6bec865f87a8852ed/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/SystemBundleActivator.java#L83