### PR TITLE
Discarded bundles during Equinox construction must avoid resolution

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/OSGiFrameworkHooks.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/internal/framework/OSGiFrameworkHooks.java
@@ -264,7 +264,9 @@ class OSGiFrameworkHooks {
 			}
 
 			private boolean isBootInit() {
-				return systemModule == null || !Module.RESOLVED_SET.contains(systemModule.getState()) || (systemModule.getState().equals(State.STARTING) && inInit);
+				State systemModuleState = systemModule == null ? State.UNINSTALLED : systemModule.getState();
+				return !Module.RESOLVED_SET.contains(systemModuleState) || systemModuleState.equals(State.RESOLVED)
+						|| (systemModuleState.equals(State.STARTING) && inInit);
 			}
 
 			@Override

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/Storage.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/Storage.java
@@ -186,7 +186,8 @@ public class Storage {
 		storage.checkSystemBundle(cachedInfo);
 		storage.refreshStaleBundles();
 		storage.installExtensions();
-		// TODO hack to make sure all bundles are in UNINSTALLED state before system bundle init is called
+		// TODO hack to make sure all bundles are in UNINSTALLED state before system
+		// bundle init is called
 		storage.getModuleContainer().setInitialModuleStates();
 		return storage;
 	}


### PR DESCRIPTION
When bundles are discarded during Equinox construction (before init is
called) the framework will force a refresh on the discarded bundles this
may trigger already resolved bundles to be re-resolved.  During the
constructor call we must prevent non-extension bundles that get
refreshed from resolving until after the framework has been initialized.

Fixes #17