### PR TITLE
Improve performance for operations that modify framework state

### DIFF
--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/BundleInfo.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/BundleInfo.java
@@ -37,6 +37,7 @@ import org.eclipse.osgi.container.ModuleContainer;
 import org.eclipse.osgi.container.ModuleContainerAdaptor.ModuleEvent;
 import org.eclipse.osgi.container.ModuleRevision;
 import org.eclipse.osgi.container.ModuleRevisionBuilder;
+import org.eclipse.osgi.framework.internal.reliablefile.ReliableFile;
 import org.eclipse.osgi.framework.log.FrameworkLogEntry;
 import org.eclipse.osgi.framework.util.CaseInsensitiveDictionaryMap;
 import org.eclipse.osgi.framework.util.ThreadInfoReport;
@@ -382,7 +383,7 @@ public final class BundleInfo {
 				throw new IOException(NLS.bind(Msg.ADAPTOR_DIRECTORY_CREATE_EXCEPTION, dir.getAbsolutePath()));
 			}
 			/* copy the entry to the cache */
-			File tempDest = File.createTempFile("staged", ".tmp", dir); //$NON-NLS-1$ //$NON-NLS-2$
+			File tempDest = ReliableFile.createTempFile("staged", ".tmp", dir); //$NON-NLS-1$ //$NON-NLS-2$
 			StorageUtil.readFile(in, tempDest);
 			if (destination.exists()) {
 				// maybe because some other thread already beat us there.

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/Storage.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/Storage.java
@@ -66,6 +66,7 @@ import org.eclipse.osgi.container.ModuleWire;
 import org.eclipse.osgi.container.ModuleWiring;
 import org.eclipse.osgi.container.builders.OSGiManifestBuilderFactory;
 import org.eclipse.osgi.container.namespaces.EclipsePlatformNamespace;
+import org.eclipse.osgi.framework.internal.reliablefile.ReliableFile;
 import org.eclipse.osgi.framework.log.FrameworkLogEntry;
 import org.eclipse.osgi.framework.util.FilePath;
 import org.eclipse.osgi.framework.util.ObjectPool;
@@ -1115,7 +1116,7 @@ public class Storage {
 	File stageContent0(InputStream in, URL sourceURL) throws BundleException {
 		File outFile = null;
 		try {
-			outFile = File.createTempFile(BUNDLE_FILE_NAME, ".tmp", childRoot); //$NON-NLS-1$
+			outFile = ReliableFile.createTempFile(BUNDLE_FILE_NAME, ".tmp", childRoot); //$NON-NLS-1$
 			String protocol = sourceURL == null ? null : sourceURL.getProtocol();
 
 			if ("file".equals(protocol)) { //$NON-NLS-1$

--- a/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/StorageUtil.java
+++ b/bundles/org.eclipse.osgi/container/src/org/eclipse/osgi/storage/StorageUtil.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.eclipse.osgi.framework.internal.reliablefile.ReliableFile;
 import org.eclipse.osgi.internal.debug.Debug;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
@@ -144,7 +145,7 @@ public class StorageUtil {
 			// we use the .dll suffix to properly test on Vista virtual directories
 			// on Vista you are not allowed to write executable files on virtual directories
 			// like "Program Files"
-			fileTest = File.createTempFile("writableArea", ".dll", installDir); //$NON-NLS-1$ //$NON-NLS-2$
+			fileTest = ReliableFile.createTempFile("writableArea", ".dll", installDir); //$NON-NLS-1$ //$NON-NLS-2$
 		} catch (IOException e) {
 			// If an exception occured while trying to create the file, it means that it is
 			// not writtable

--- a/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/storagemanager/StorageManager.java
+++ b/bundles/org.eclipse.osgi/supplement/src/org/eclipse/osgi/storagemanager/StorageManager.java
@@ -198,7 +198,7 @@ public final class StorageManager {
 	private void initializeInstanceFile() throws IOException {
 		if (instanceFile != null || readOnly)
 			return;
-		this.instanceFile = File.createTempFile(".tmp", ".instance", managerRoot); //$NON-NLS-1$//$NON-NLS-2$
+		this.instanceFile = ReliableFile.createTempFile(".tmp", ".instance", managerRoot); //$NON-NLS-1$//$NON-NLS-2$
 		this.instanceFile.deleteOnExit();
 		instanceLocker = LocationHelper.createLocker(instanceFile, lockMode, false);
 		instanceLocker.lock();
@@ -741,7 +741,7 @@ public final class StorageManager {
 	public File createTempFile(String file) throws IOException {
 		if (readOnly)
 			throw new IOException(Msg.fileManager_illegalInReadOnlyMode);
-		File tmpFile = File.createTempFile(file, ReliableFile.tmpExt, base);
+		File tmpFile = ReliableFile.createTempFile(file, ReliableFile.tmpExt, base);
 		// bug 350106: do not use deleteOnExit()  If clients really want that the
 		// they can call it themselves.
 		return tmpFile;


### PR DESCRIPTION
Many places in the internal management of framework state use File.createTempFile to stage updates before moving them to their final location on disk.  The issue is File.createTempFile uses SecureRandom to generate unique file names.  This is a bit overkill for our usages and can cause slowdown on some environments when used extensively.

This change implements a simple version of createTempFile that can be used for only internal purposes for the framework.