### PR TITLE
 POM and product version changes for 4.25 release

### DIFF
--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/pom.xml
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.aarch64/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>launcher-binary-parent</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../launcher-binary-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/pom.xml
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx.x86_64/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>launcher-binary-parent</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../launcher-binary-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.launcher.cocoa.macosx/pom.xml
+++ b/bundles/org.eclipse.equinox.launcher.cocoa.macosx/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>launcher-binary-parent</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../launcher-binary-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64/pom.xml
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.aarch64/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>launcher-binary-parent</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../launcher-binary-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.loongarch64/pom.xml
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.loongarch64/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>launcher-binary-parent</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../launcher-binary-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le/pom.xml
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.ppc64le/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>launcher-binary-parent</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../launcher-binary-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64/pom.xml
+++ b/bundles/org.eclipse.equinox.launcher.gtk.linux.x86_64/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>launcher-binary-parent</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../launcher-binary-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/pom.xml
+++ b/bundles/org.eclipse.equinox.launcher.win32.win32.x86_64/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>launcher-binary-parent</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../launcher-binary-parent</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.equinox.launcher/pom.xml
+++ b/bundles/org.eclipse.equinox.launcher/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.framework</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox</groupId>

--- a/bundles/org.eclipse.osgi.compatibility.state/pom.xml
+++ b/bundles/org.eclipse.osgi.compatibility.state/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.framework</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.osgi</groupId>

--- a/bundles/org.eclipse.osgi.services/pom.xml
+++ b/bundles/org.eclipse.osgi.services/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.framework</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.osgi</groupId>

--- a/bundles/org.eclipse.osgi.tests/pom.xml
+++ b/bundles/org.eclipse.osgi.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.framework</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.osgi</groupId>

--- a/bundles/org.eclipse.osgi.util/pom.xml
+++ b/bundles/org.eclipse.osgi.util/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.framework</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.osgi</groupId>

--- a/bundles/org.eclipse.osgi/pom.xml
+++ b/bundles/org.eclipse.osgi/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.framework</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.osgi</groupId>

--- a/bundles/org.eclipse.osgi/supplement/pom.xml
+++ b/bundles/org.eclipse.osgi/supplement/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>rt.equinox.framework</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../../</relativePath>
   </parent>
 

--- a/features/org.eclipse.equinox.executable.feature/pom.xml
+++ b/features/org.eclipse.equinox.executable.feature/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>rt.equinox.framework</artifactId>
     <groupId>org.eclipse.equinox.framework</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../../</relativePath>
   </parent>
   <groupId>org.eclipse.equinox.feature</groupId>

--- a/launcher-binary-parent/pom.xml
+++ b/launcher-binary-parent/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse.equinox.framework</groupId>
     <artifactId>rt.equinox.framework</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>launcher-binary-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
Tracked in [eclipse.platform.releng.aggregator#290](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/290) and [eclipse.platform.releng.aggregator#291](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/291)

Need to wait to merge until after 4.24 Release