### PR TITLE
Remove apitools.ee.feature from Oomph setup.

### DIFF
--- a/releng/org.eclipse.equinox.releng/Equinox.setup
+++ b/releng/org.eclipse.equinox.releng/Equinox.setup
@@ -31,11 +31,6 @@
         href="EquinoxConfiguration.setup#/"/>
   </annotation>
   <setupTask
-      xsi:type="setup.p2:P2Task">
-    <requirement
-        name="org.eclipse.pde.api.tools.ee.feature.feature.group"/>
-  </setupTask>
-  <setupTask
       xsi:type="setup:CompoundTask"
       name="refresh.enabled">
     <setupTask


### PR DESCRIPTION
Not needed at all and to be removed via
eclipse-pde/eclipse.pde#147