### PR TITLE
Incorrect org.osgi Maven-dependencies in generated pom of o.e.osgi.util

### DIFF
--- a/bundles/org.eclipse.osgi.util/META-INF/MANIFEST.MF
+++ b/bundles/org.eclipse.osgi.util/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %osgiUtil
 Bundle-SymbolicName: org.eclipse.osgi.util
-Bundle-Version: 3.7.0.qualifier
+Bundle-Version: 3.7.100.qualifier
 Bundle-Description: %osgiUtilDes
 Bundle-Vendor: %eclipse.org
 Bundle-Localization: plugin

--- a/bundles/org.eclipse.osgi.util/forceQualifierUpdate.txt
+++ b/bundles/org.eclipse.osgi.util/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 403352 - Update all parent versions to match our build stream
+Incorrect org.osgi Maven-dependencies in generated pom of o.e.osgi.util

--- a/bundles/org.eclipse.osgi.util/pom.xml
+++ b/bundles/org.eclipse.osgi.util/pom.xml
@@ -19,7 +19,7 @@
   </parent>
   <groupId>org.eclipse.osgi</groupId>
   <artifactId>org.eclipse.osgi.util</artifactId>
-  <version>3.7.0-SNAPSHOT</version>
+  <version>3.7.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
   <build>
     <plugins>


### PR DESCRIPTION
Tracked in
https://github.com/eclipse-equinox/equinox.framework/issues/70